### PR TITLE
KeyValueDefinitionBase non generic as new base class

### DIFF
--- a/Assets/com.fluid.database/Runtime/Definitions/KeyValueDefinitionBase.cs
+++ b/Assets/com.fluid.database/Runtime/Definitions/KeyValueDefinitionBase.cs
@@ -6,8 +6,10 @@ namespace CleverCrow.Fluid.Databases {
 
         V DefaultValue { get; }
     }
+    
+    public abstract class KeyValueDefinitionBase : ScriptableObject {}
 
-    public abstract class KeyValueDefinitionBase<V> : ScriptableObject, IKeyValueDefinition<V> {
+    public abstract class KeyValueDefinitionBase<V> : KeyValueDefinitionBase, IKeyValueDefinition<V> {
         protected const string CREATE_PATH = "Fluid/Database";
 
         public string key;


### PR DESCRIPTION
Created new base class for KeyValueDefinitionBase<T> in the form of KeyValueDefinitionBase. This lets all variable references be serialized in the Inspector without having to serialized ScriptableObject.

Then all KeyValueDefinitions can be found in the project easily.